### PR TITLE
Deutsche Übersetzung der restlichen Circle Undone-Spielerkarten

### DIFF
--- a/translations/de/pack/tcu/bbt.json
+++ b/translations/de/pack/tcu/bbt.json
@@ -1,0 +1,83 @@
+[
+	{
+		"code": "05313",
+		"name": "Geweihter Spiegel",
+		"slot": "Zubehör",
+		"text": "Nur 1 pro Deck.\n<b>Erzwungen</b> - Nachdem der geweihte Spiegel ins Spiel gekommen ist: Durchsuche deine Gebunden-Karten nach 3 Kopien von Besänftigende Melodie. Füge 1 davon deiner Hand hinzu und mische die 2 anderen in dein Deck. Sobald der geweihte Spiegel das Spiel verlässt, finde jede jener Kopien von Besänftigende Melodie (<i>selbst wenn sie sich nicht im Spiel befindet</i>) und entferne sie aus dem Spiel.",
+		"traits": "Gegenstand. Relikt. Okkult. Gesegnet."
+	},
+	{
+		"code": "05314",
+		"flavor": "…Et leur chanson se mêle au clair de lune,\nAu calme clair de lune triste et beau…\n- Paul Verlaine, „Clair de Lune“",
+		"name": "Besänftigende Melodie",
+		"text": "Gebunden (Geweihter Spiegel).\nHeile 2 Schaden oder 2 Horror (oder eine beliebige Kombination aus beidem) von Ermittlern und/oder [[Verbündeter]]-Vorteilskarten an deinem Ort. Ziehe 1 Karte.",
+		"traits": "Zauber."
+	},
+	{
+		"code": "05315",
+		"name": "„Es gibt Schlimmeres…“",
+		"text": "Schnell. Spiele diese Karte, sobald dir Schaden und/oder Horror zugefügt wird.\nHebe bis zu 2 Schaden und/oder Horror auf, der dir gerade zugefügt worden ist. Dann erhältst du genauso viele Ressourcen.",
+		"traits": "Geist."
+	},
+	{
+		"code": "05316",
+		"name": "Okkultes Lexikon",
+		"slot": "Hand",
+		"text": "Nur 1 pro Deck.\n<b>Erzwungen</b> - Nachdem das okkulte Lexikon ins Spiel gekommen ist: Durchsuche deine Gebunden-Karten nach 3 Kopien von Blutritual. Füge 1 davon deiner Hand hinzu und mische die 2 anderen in dein Deck. Sobald das okkulte Lexikon das Spiel verlässt, finde jede jener Kopien von Blutritual (<i>selbst wenn sie sich nicht im Spiel befindet</i>) und entferne sie aus dem Spiel.",
+		"traits": "Gegenstand. Buch. Okkult.",
+	},
+	{
+		"code": "05317",
+		"name": "Blutritual",
+		"text": "Gebunden (Okkultes Lexikon).\nZiehe 2 Karten. Lege bis zu 2 Karten von deiner Hand ab. Für jede so abgelegte Karte darfst du entweder 1 Ressource erhalten oder 1 Ressource ausgeben, um einem Gegner an deinem Ort 1 Schaden zuzufügen. Diese Aktion provoziert keine Gelegenheitsangriffe.",
+		"traits": "Zauber."
+	},
+	{
+		"code": "05318",
+		"flavor": "Unwissenheit ist ein Segen, den du dir nicht leisten kannst.",
+		"name": "Das Undenkbare erblicken",
+		"text": "Mische eine beliebige Zahl an Nicht-Schwäche-Karten von deiner Hand in dein Deck. Ziehe Karten, bis du dein Handkartenlimit erreicht hast. Entferne Das Undenkbare Erblicken aus dem Spiel.",
+		"traits": "Erkenntnis."
+	},
+	{
+		"code": "05319",
+		"flavor": "„Ja, ja, schon klar. Das hast du schon die letzten drei Male gesagt.“",
+		"name": "„Du schuldest mir was!“",
+		"text": "Sieh dir die Hand eines anderen Ermittlers an. Du darfst eine Nicht-Schwäche-Karte von der Hand jenes Ermittlers unter deiner Kontrolle spielen. Falls du dies tust, ziehen du und jener Ermittler je 1 Karte.",
+		"traits": "Gefallen. Schachzug."
+	},
+	{
+		"code": "05320",
+		"flavor": "Harpyie schreit: - 's ist Zeit, 's ist Zeit!\n- William Shakespeare, Macbeth",
+		"name": "Doublette",
+		"slot": "Arkan",
+		"text": "Außergewöhnlich.\n[reaction] Nachdem du eine Ereigniskarte gespielt hast, erschöpfe Doublette: Spiele jene Ereigniskarte erneut, als ob sie sich auf deiner Hand befände.",
+		"traits": "Ritual."
+	},
+	{
+		"code": "05321",
+		"name": "Welken",
+		"slot": "Arkan",
+		"text": "[action]: <b>Kampf.</b> Dieser Angriff verwendet [willpower] statt [combat]. Du bekommst für diesen Angriff +2 [willpower]. Falls ein [skull]-, [cultist]-, [tablet]- oder [elder_thing]-Symbol während dieses Angriffs enthüllt wird, bekommt der angegriffene Gegner für den Rest des Zuges -1 Kampf, -1 Ausdauer und -1 Entkommen (bis zu einem Minimum von 1).",
+		"traits": "Zauber."
+	},
+	{
+		"code": "05322",
+		"name": "Sechster Sinn",
+		"slot": "Arkan",
+		"text": "[action]: <b>Ermitteln.</b> Verwende beim Ermitteln [willpower] statt [intellect]. Du bekommst für diesen Ermittlung +2 [willpower]. Falls ein [skull]-, [cultist]-, [tablet]- oder [elder_thing]-Symbol während dieser Probe enthüllt wird, darfst du einen enthüllten bis zu 2 Verbindungen von deinem Ort entfernten Ort wählen; du ermittelst nun, als ob du dich zusätzlich zu deinem Ort auch am gewählten Ort befändest (du darfst einen der beiden Schleierwerte verwenden).",
+		"traits": "Zauber."
+	},
+	{
+		"code": "05323",
+		"name": "Köder",
+		"text": "Hänge diese Karte an deinen Ort oder einen Verbundenen Ort an.\nWährend der Gegnerphase nimmt jeder Gegner, der sich bewegt, den kürzesten Weg in Richtung des Ortes mit dieser Verstärkung, statt sich normal zu bewegen.\n <b>Erzwungen</b> - Solange diese Verstärkung am Ende der Runde angehängt ist: Lege den Köder ab.",
+		"traits": "Trick."
+	},
+	{
+		"code": "05324",
+		"name": "Wendung zum Guten",
+		"text": "Schnell. Spiele diese Karte, sobald du einen Chaosmarker enthüllst, der deinen Fertigkeitswert während einer Fertigkeitsprobe auf 0 senken würde (einschließlich des [auto_fail]-Markers).\nHebe diesen Marker auf und behandle ihn stattdessen als einen [elder_sign]-Marker.",
+		"traits": "Glücksfall. Gesegnet."
+	}
+]

--- a/translations/de/pack/tcu/fgg.json
+++ b/translations/de/pack/tcu/fgg.json
@@ -34,7 +34,7 @@
 	{
 		"code": "05191",
 		"name": "Tennessee Sour Mash",
-		"text": "Anwendungen (3 supplies).\n[fast] Erschöpfe Tennessee Sour Mash und gib 1 Vorrat aus: Du bekommst für eine Fertigkeitsprobe auf einer Verratskarte +2 [willpower].\n[action] Lege Tennessee Sour Mash ab: <b>Kampf.</b> Du bekommst für diesen Angriff +3 [combat]. Fall dieser Angriff gegen einen Nicht-[[Elite]]-Gegner erfolgreich ist, entkommst du ihm automatisch.",
+		"text": "Anwendungen (3 Vorräte).\n[fast] Erschöpfe Tennessee Sour Mash und gib 1 Vorrat aus: Du bekommst für eine Fertigkeitsprobe auf einer Verratskarte +2 [willpower].\n[action] Lege Tennessee Sour Mash ab: <b>Kampf.</b> Du bekommst für diesen Angriff +3 [combat]. Fall dieser Angriff gegen einen Nicht-[[Elite]]-Gegner erfolgreich ist, entkommst du ihm automatisch.",
 		"traits": "Gegenstand. Illegal."
 	},
 	{

--- a/translations/de/pack/tcu/icc.json
+++ b/translations/de/pack/tcu/icc.json
@@ -1,30 +1,77 @@
 [
-    {
-        "code": "05274",
-        "name": "Agency Backup",
-        "text": "Agency Backup may be assigned damage and/or horror dealt to other investigators at your location.\n[free] Exhaust Agency Backup and deal 1 damage to it: Deal 1 damage to an enemy at your location.\n[free] Exhaust Agency Backup and deal 1 horror to it: Discover 1 clue at your location.",
-        "traits": "Ally. Agency.",
-        "slot": "Ally"
-    },
-    {
-        "code": "05279",
-        "name": "Dayana Esperence",
-        "subname": "Deals with \"Devils\"",
-        "text": "Uses (3 secrets).\n[free]: Attach a non-weakness [[Spell]] event from your hand to Dayana Esperence. Limit 1 event attached to her.\nThe attached event may be played as if it were in your hand. It is not placed in your discard pile after it is played <i>(it remains attached)</i>. As an additional cost to play the attached event, exhaust Dayana Esperence and spend 1 secret.",
-        "traits": "Ally. Witch.",
-        "slot": "Ally"
-    },
-    {
-        "code": "05280",
-        "name": "Deny Existence",
-        "text": "Fast. Play when an encounter card or enemy attack would cause you to do one of the following (choose one): Discard cards from hand, lose resources, lose actions, take damage, or take horror.\nYou ignore that aspect of the effect. Then, perform the opposite of that aspect (draw cards, gain resources, gain additional actions, heal damage, or heal horror, respectively).",
-        "traits": "Spell. Paradox."
-    },
-    {
-        "code": "05281",
-        "flavor": "You never really know what you are capable of until something is trying to eat you.",
-        "name": "Trial by Fire",
-        "text": "Fast. Play only during your turn.\nChoose one of your skills. Until the end of your turn, set the base value of that skill to 5.",
-        "traits": "Spirit."
-    }
+	{
+		"code": "05273",
+		"name": "Mark-1-Granaten",
+		"slot": "Hand",
+		"text": "Anwendungen (3 Vorräte). Falls Mark-1-Granaten keine Vorräte hat, lege sie ab.\n[action] Gib 1 Vorrat aus: <b>Kampf.</b> Du bekommst für diesen Angriff +2 [combat]. Falls dieser Angriff gelingt, fügt dieser Angriff statt seines normalen Schadens jedem Gegner und jedem Ermittler an deinem Ort 2 Schaden zu <i>(jeder zusätzliche Schaden wird dem angegriffenen Gegner zugefügt).</i>",
+		"traits": "Gegenstand. Waffe. Fernkampf.",
+	},
+	{
+		"code": "05274",
+		"name": "Unterstützungstrupp der Behörde",
+		"slot": "Verbündeter",
+		"text": "Dem Unterstützungstrupp der Behörde darf Schaden und/oder Horror zugewiesen werden, der anderen Ermittlern an deinem Ort zugefügt wird.\n[free] Erschöpfe den Unterstützungstrupp der Behörde und füge dieser Karte 1 Schaden zu: Füge einem Gegner an deinem Ort 1 Schaden zu.\n[free] Erschöpfe den Unterstützungstrupp der Behörde und füge ihm 1 Horror zu: Du entdeckst 1 Hinweis an deinem Ort.",
+		"traits": "Verbündeter. Behörde."
+	},
+	{
+		"code": "05275",
+		"name": "Entsetzliche Offenbarung",
+		"text": "Du entdeckst 3 Hinweise an deinem Ort. Gib eine beliebige Anzahl deiner Hinweise einem anderen Ermittler oder platziere eine beliebige Anzahl deiner Hinweise auf einen beliebigen Ort. Du bist besiegt und erleidest 1 seelisches Trauma. Diese Aktion provoziert keine Gelegenheitsangriffe.",
+		"traits": "Geist."
+	},
+	{
+		"code": "05276",
+		"flavor": "Vielleicht hätte Gilman sein Studium nicht so intensiv betreiben sollen.\n-H. P. Lovecraft, <u>Träume im Hexenhaus</u>",
+		"name": "Lernbegierig",
+		"text": "Dauerhaft.\nDu beginnst jedes Spiel mit 1 zusätzlichen Karte auf deiner Starthand.",
+		"traits": "Talent."
+	},
+	{
+		"code": "05277",
+		"name": "Kleine Gefälligkeit",
+		"text": "Füge einem Nicht-[[Elite]]-Gegner an deinem Ort 1 Schaden zu.\n[reaction] Sobald du Kleine Gefälligkeit ausspielst, erhöhe die Kosten dieser Karte um 2: Ändere „Füge 1 Schaden zu“ in „Füge 2 Schaden zu“.\n[reaction] Sobald du Kleine Gefälligkeit ausspielst, erhöhe die Kosten dieser Karte um 2: Ändere „an deinem Ort“ in „an einem bis zu 2 Verbindungen entfernten Ort“.",
+		"traits": "Gefallen. Dienst."
+	},
+	{
+		"code": "05278",
+		"flavor": "Verliere nie den Blick für das wirklich Wichtige.",
+		"name": "Neuer Tag, neues Geld",
+		"text": "Dauerhaft.\nDu beginnst jedes Spiel mit 2 zusätzlichen Ressourcen.",
+		"traits": "Talent."
+	},
+	{
+		"code": "05279",
+		"name": "Dayana Esperence",
+		"subname": "Paktiert mit „Teufeln“",
+		"slot": "Verbündeter",
+		"text": "Anwendungen (3 Geheimnisse).\n[free]: Hänge eine Nicht-Schwäche-[[Zauber]]-Ereigniskarte von deiner Hand an Dayana Esperence an. Nur 1 Ereigniskarte kann an sie angehängt werden.\nDie angehängte Karte darf gespielt werden, als ob sie sich auf deiner Hand befände. Sie wird nach dem Spielen nicht auf den Ablagestapel platziert <i>(sie bleibt angehängt)</i>. Als zusätzliche Kosten, um die angehängte Ereigniskarte zu spielen, erschöpfe Dayana Esperence und gib 1 Geheimnis aus.",
+		"traits": "Verbündeter. Hexe."
+	},
+	{
+		"code": "05280",
+		"name": "Existenz verleugnen",
+		"text": "Schnell. Spiele diese Karte, sobald dich eine Begegnungskarte oder ein Angriff eines Gegners zu einem der folgenden Effekte zwingen würde (wähle einen): Karten von der Hand ablegen, Ressourcen verlieren, Aktionen verlieren, Schaden nehmen oder Horror nehmen.\nDu ignorierst jenen Aspekt des Effekts. Führe dann das entsprechende Gegenteil davon durch (Karten ziehen, Ressourecen erhalten, zusätzliche Aktionen erhalten, Schaden heilen oder Horror heilen).",
+		"traits": "Zauber. Paradox."
+	},
+	{
+		"code": "05281",
+		"flavor": "Du weißt nie, was wirklich in dir steckt, bis es einmal wirklich darauf ankommt.",
+		"name": "Feuerprobe",
+		"text": "Schnell. Spiele diese Karte nur in deinem Zug.\nWähle 1 deiner Fertigkeiten. Setze den Grundwert jener Fertigkeit bis zum Ende deines Zuges auf 5.",
+		"traits": "Geist."
+	},
+	{
+		"code": "05282",
+		"name": "Lockvogeltaktik",
+		"text": "Entweder (wähle eins):\n- <b>Entkommen.</b> Falls die Probe gelingt und es ein Nicht-[[Elite]]-Gegner ist, entkomme diesem Gegner und bewege ihn an einen Verbundenen Ort.\n- <b>Entkommen.</b> Nur bei einem Nicht-[[Elite]]-Gegner an einem Verbundenen Ort verwenden. Falls die Probe gelingt, entkomme diesem Gegner und tausche mit ihm den Ort.",
+		"traits": "Taktik."
+	},
+	{
+		"code": "05283",
+		"name": "Anna Kaslow",
+		"subname": "Mysteriöse Wahrsagerin",
+		"slot": "Verbündeter",
+		"text": "Du hast 2 zusätzliche Tarotslots.\n[reaction] Sobald das Spiel beginnt, falls sich Anna Kaslow auf deiner Starthand befindet: Bringe sie ins Spiel.\n[reaction] Nachdem Anna Kaslow ins Spiel gekommen ist: Durchsuche dein Deck nach einer [[Tarot]]-Vorteilskarte und bringe sie ins Spiel.",
+		"traits": "Verbündeter. Hellsichtig."
+	}
 ]

--- a/translations/de/pack/tcu/tcu.json
+++ b/translations/de/pack/tcu/tcu.json
@@ -11,7 +11,7 @@
 	},
 	{
 		"back_flavor": "Joe Diamond ist Privatdetektiv. Ihm eilt der Ruf voraus, auch jene Fälle lösen zu können, die jeder andere als übernatürlichen Unsinn abtut. Er führt seine Ermittlungen gründlich durch und man sollte nicht den Fehler machen, ihn zu unterschätzen. Zu seinen Kunden gehören sowohl Wohlhabende als auch Unglücksraben. Kein Fall ist ihm zu groß, zu klein, zu seltsam oder zu gefährlich. Joe hat die Erfahrung gemacht, dass es richtig unangenehm werden kann, wenn man der Wahrheit auf die Spur kommt - und genau das mag er.",
-		"back_text": "<b>Deckgröße</b>: 40.\n<b>Deckbau-Optionen</b>: Sucherkarten ([seeker]) Stufe 0-5, Wächterkarten ([guardian]) Stufe 0-2, Neutrale Karten Stufe 0-5.\n<b>Deckbau-Voraussetzungen</b> (zählen nicht gegen die Deckgröße): M1911-Colts des Detektivs, Ungelöster Fall, 1 zufällige Grundschwäche.\n<b>Zusätzliche Voraussetzungen</b>: Dein Deck muss mindesten 11 [[Erkenntnis]]-Ereigniskarten enthalten (einschließlich Ungelöster Fall). Während der Vorbereitung jedes Szenarios musst du 11 11 [[Erkenntnis]]-Ereigniskarten aus deinem Deck wählen (1 davon muss Ungelöster Fall sein) und sie zum separaten „Spürnase-Deck“ zusammenmischen.",
+		"back_text": "<b>Deckgröße</b>: 40.\n<b>Deckbau-Optionen</b>: Sucherkarten ([seeker]) Stufe 0-5, Wächterkarten ([guardian]) Stufe 0-2, Neutrale Karten Stufe 0-5.\n<b>Deckbau-Voraussetzungen</b> (zählen nicht gegen die Deckgröße): M1911-Colts des Detektivs, Ungelöster Fall, 1 zufällige Grundschwäche.\n<b>Zusätzliche Voraussetzungen</b>: Dein Deck muss mindesten 11 [[Erkenntnis]]-Ereigniskarten enthalten (einschließlich Ungelöster Fall). Während der Vorbereitung jedes Szenarios musst du 11 [[Erkenntnis]]-Ereigniskarten aus deinem Deck wählen (1 davon muss Ungelöster Fall sein) und sie zum separaten „Spürnase-Deck“ zusammenmischen.",
 		"code": "05002",
 		"name": "Joe Diamond",
 		"subname": "Der Privatdetektiv",
@@ -233,7 +233,7 @@
 	{
 		"code": "05032",
 		"name": "Existenz verleugnen",
-		"text": "Schnell. Spiele diese Karte, sobald dich eine Begegnungskarte oder ein Angriff eines Gegners zu 1 der folgenden Effekte zwingen würde (wähle eins): Karten von der Hand ablegen, Ressourcen verlieren, Aktionen verlieren, Schaden nehmen oder Horror nehmen.\nDu ignorierst jenen Aspekt des Effekts. <i>(Alle weiteren Effekte werden normal abgehandelt.)</i>",
+		"text": "Schnell. Spiele diese Karte, sobald dich eine Begegnungskarte oder ein Angriff eines Gegners zu einem der folgenden Effekte zwingen würde (wähle einen): Karten von der Hand ablegen, Ressourcen verlieren, Aktionen verlieren, Schaden nehmen oder Horror nehmen.\nDu ignorierst jenen Aspekt des Effekts. <i>(Alle weiteren Effekte werden normal abgehandelt.)</i>",
 		"traits": "Zauber. Paradox."
 	},
 	{

--- a/translations/de/pack/tcu/uad.json
+++ b/translations/de/pack/tcu/uad.json
@@ -1,9 +1,9 @@
 [	
 	{
 		"code": "05229",
-		"flavor": "\"Keinen Schritt weiter!\"",
+		"flavor": "„Keinen Schritt weiter!“",
 		"name": "Warnschuss",
-		"text": "Als zusätzliche Kosten, um Warnschuss zu spielen, gib 1 Munition einer [[Feuerwaffe]]-Vorteilskarte aus, die du kontrollierst.\nBewege alle Nicht-[[Elite]]-Gegner an deinem Ort an einen verbundenen Ort. Diese Attacke provoziert keine Gelegenheitsangriffe.",
+		"text": "Als zusätzliche Kosten, um Warnschuss zu spielen, gib 1 Munition einer [[Feuerwaffe]]-Vorteilskarte aus, die du kontrollierst.\nBewege alle Nicht-[[Elite]]-Gegner an deinem Ort an einen verbundenen Ort. Diese Aktion provoziert keine Gelegenheitsangriffe.",
 		"traits": "Taktik. Trick."
 	},
 	{
@@ -14,7 +14,7 @@
 	},
 	{
 		"code": "05231",
-		"flavor": "... und Macht verdirbt.",
+		"flavor": "… und Macht verdirbt.",
 		"name": "Wissen ist Macht",
 		"text": "Schnell. Spiele diese Karte nur in deinem Zug.\nWähle eine [[Buch]]-oder [[Zauber]]-Vorteilskarte, die du kontrollierst, oder enthülle eine [[Buch]]- oder [[Zauber]]-Vorteilskarte von deiner Hand. Handle eine [action]- oder [free]-Fähigkeit jener Vorteilskarte ab und ignoriere dafür alle Kosten <i>(einschließlich ihrer [action]-Kosten, sofern vorhanden)</i>. Falls jene Vorteilskarte auf deiner Hand war, darfst du sie dann ablegen, um 1 Karte zu ziehen.",
 		"traits": "Erkenntnis."
@@ -29,18 +29,18 @@
   	{
 		"code": "05233",
 		"name": "Investitionen",
-		"text": "Anwendungen (0 Vorräte). Nur bis zu 10 Vorräte auf Investitionen.\n[free] Erschöpfe Investitionen: Platziere 1 Vorrat auf dieser Karte.\n[action] Erschöpfe Investitionen und lege diese Karte ab: Bewege alle Vorräte von dieser Karte als Ressourcen in deinen Ressourcenvorrat.",
+		"text": "Anwendungen (0 Vorräte). Nur bis zu 10 Vorräte auf Investitionen.\n[free] Erschöpfe Investitionen: Platziere 1 Vorrat auf diese Karte.\n[action] Erschöpfe Investitionen und lege diese Karte ab: Bewege alle Vorräte von dieser Karte als Ressourcen in deinen Ressourcenvorrat.",
 		"traits": "Verbindung."
   	},
 	{
 		"code": "05234",
 		"name": "Ablenkungsmanöver",
-		"text": "<b>Entkommen.</b> Entkomme automatisch einem Nicht-[[Elite]]-Gegner an deinem Ort.\n[reaction] Sobald du das Ablenkungsmanöver spielst, erhöhe die Kosten dieser Karte um 2: Ändere \"einem Nicht-[[Elite]]-Gegner\" in \"bis zu 2 Nicht-[[Elite]]-Gegnern.\"\n[reaction] Sobald du das Ablenkungsmanöver spielst, erhöhe die Kosten dieser Karte um 2: Ändere \"an deinem Ort\" in \"an einem bis zu 2 Verbindungen entfernten Ort.\"",
+		"text": "<b>Entkommen.</b> Entkomme automatisch einem Nicht-[[Elite]]-Gegner an deinem Ort.\n[reaction] Sobald du das Ablenkungsmanöver spielst, erhöhe die Kosten dieser Karte um 2: Ändere „einem Nicht-[[Elite]]-Gegner“ in „bis zu 2 Nicht-[[Elite]]-Gegnern.“\n[reaction] Sobald du das Ablenkungsmanöver spielst, erhöhe die Kosten dieser Karte um 2: Ändere „an deinem Ort“ in „an einem bis zu 2 Verbindungen entfernten Ort.“",
 		"traits": "Gefallen. Dienst."
 	},
 	{
 		"code": "05235",
-		"flavor": "Ludwig Prinn war sein Autor, der auf dem Höhepunkt der Hexenprozesse in Brüssel auf dem Scheiterhaufen starb. - frei nach Robert Bloch, \"The Shambler from the Stars\"",
+		"flavor": "Ludwig Prinn war sein Autor, der auf dem Höhepunkt der Hexenprozesse in Brüssel auf dem Scheiterhaufen starb.\n- frei nach Robert Bloch, „The Shambler from the Stars“ ",
 		"name": "De Vermis Mysteriis",
 		"slot": "Hand",
 		"subname": "Vorzeichen der Schwarzen Sterne",
@@ -57,7 +57,7 @@
 	{
 		"code": "05237",
 		"name": "Glück oder Schicksal",
-		"text": "Schnell. Spiele diese Karte, sobald Verderben auf einer beliebigen Szenariokarte platziert werden würde.\nMax. 1 pro Spiel.\nHebe 1 Verderben auf, das gerade auf jener Karte platziert worden ist. Schicke Glück oder Schicksal ins Exil.",
+		"text": "Schnell. Spiele diese Karte, sobald Verderben auf eine beliebigen Szenariokarte platziert werden würde.\nMax. 1 pro Spiel.\nHebe 1 Verderben auf, das gerade auf jene Karte platziert worden ist. Schicke Glück oder Schicksal ins Exil.",
 		"traits": "Glücksfall. Gesegnet."
 	}
 ]

--- a/translations/de/pack/tcu/wos.json
+++ b/translations/de/pack/tcu/wos.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "05151",
-		"flavor": "\"Bitte überlass Sie das uns. Falls Sie hier nochmal rumschnüffeln, fahren Sie ein.\"",
+		"flavor": "„Bitte überlass Sie das uns. Falls Sie hier nochmal rumschnüffeln, fahren Sie ein.“",
 		"name": "Alice Luxley",
 		"slot": "Verbündeter",
 		"subname": "Furchtloser Bulle",
@@ -11,13 +11,13 @@
 	{
 		"code": "05152",
 		"name": "Gut gepflegt",
-		"text": "Schnell. Spiele diese Karte nur in deinem Zug.\n Hänge diese Karte an eine [[Gegenstand]]-Vorteilskarte an, die du kontrollierst. Nur 1 pro Vorteilskarte.\n[reaction] Nachdem die Vorteilskarte mit dieser Verstärkung abgelegt worden ist: Schicke die Vorteilskarte zusammen mit jeder anderen [[Verbesserung]], die an sie angehängt war, auf die Hand ihres Besitzers zurück.",
+		"text": "Schnell. Spiele diese Karte nur in deinem Zug.\nHänge diese Karte an eine [[Gegenstand]]-Vorteilskarte an, die du kontrollierst. Nur 1 pro Vorteilskarte.\n[reaction] Nachdem die Vorteilskarte mit dieser Verstärkung abgelegt worden ist: Schicke die Vorteilskarte zusammen mit jeder anderen [[Verbesserung]], die an sie angehängt war, auf die Hand ihres Besitzers zurück.",
 		"traits": "Verbesserung."
 	},
 	{
 		"code": "05153",
-		"flavor": "\"Möchten Sie das wirklich wissen? Dann gibt es kein Zurück mehr.\"",
-		"name": "Mr. \"Rook\"",
+		"flavor": "„Möchten Sie das wirklich wissen? Dann gibt es kein Zurück mehr.“",
+		"name": "Mr. „Rook“",
 		"slot": "Verbündeter",
 		"subname": "Geheimnishändler",
 		"text": "Anwendungen (3 Geheimnisse).\n[free] Erschöpfe Mr. \"Rook\" und gib 1 Geheimnis aus: Durchsuche die obersten 3, 6 oder 9 Karten deines Decks nach einer beliebigen Karte und ziehe sie. Falls unter den angesehenen Karten mindestens 1 Schwäche ist, ziehe außerdem 1 von ihnen. Mische dein Deck.",
@@ -25,9 +25,9 @@
 	},
 	{
 		"code": "05154",
-		"name": "\"Hawk-Eye\"-Klappkamera",
+		"name": "„Hawk Eye“-Klappkamera",
 		"slot": "Hand",
-		"text": "[reaction] Nachdem der letzte Hinweis an deinem Ort entdeckt worden ist: Platziere 1 Ressource <i>(aus dem Ressourcenvorrat)</i> als Beweis auf diese Karte. (Nur ein Mal pro Spiel an jedem Ort.)\nSolange die \"Hawk-Eye\"-Klappkamera...\n- ... 1 oder mehr Beweise hat, bekommst du +1 [willpower].\n- ... 2 oder mehr Beweise hat, bekommst du +1 [intellect].\n- ... 3oder mehr Beweise hat, bekommst du +1 sanity.",
+		"text": "[reaction] Nachdem der letzte Hinweis an deinem Ort entdeckt worden ist: Platziere 1 Ressource <i>(aus dem Ressourcenvorrat)</i> als Beweis auf diese Karte. (Nur ein Mal pro Spiel an jedem Ort.)\nSolange die „Hawk Eye“-Klappkamera…\n- … 1 oder mehr Beweise hat, bekommst du +1 [willpower].\n- … 2 oder mehr Beweise hat, bekommst du +1 [intellect].\n- … 3 oder mehr Beweise hat, bekommst du +1 geistige Gesundheit.",
 		"traits": "Gegenstand. Werkzeug."
 	},
 	{
@@ -35,7 +35,7 @@
 		"name": "Henry Wan",
 		"slot": "Verbündeter",
 		"subname": "Aufstrebender Schauspieler",
-		"text": "[action] Erschöpfe Henry Wan: Enthülle nacheinander Marker aus dem Chaosbeutel, bis du dich entscheidest aufzuhören oder bist du ein [skull]-, [cultist]-, [tablet]-, [elder_thing]- oder [auto_fail]-Symbol enthüllst.\n- Falls du dich entscheidest aufzuhören, darfst du für jeden durch diesen Effekt enthüllten Marker entweder 1 Karte ziehen oder 1 Ressource erhalten.\n- Falls du ein [skull]-, [cultist]-, [tablet]-, [elder_thing]- oder [auto_fail]-Symbol enthüllst, tust du nichts.",
+		"text": "[action] Erschöpfe Henry Wan: Enthülle nacheinander Marker aus dem Chaosbeutel, bis du dich entscheidest aufzuhören oder bist du ein [skull]-, [cultist]-, [tablet]-, [elder_thing]- oder [auto_fail]-Symbol enthüllst.\n- Falls du dich entscheidest, aufzuhören, darfst du für jeden durch diesen Effekt enthüllten Marker entweder 1 Karte ziehen oder 1 Ressource erhalten.\n- Falls du ein [skull]-, [cultist]-, [tablet]-, [elder_thing]- oder [auto_fail]-Symbol enthüllst, tust du nichts.",
 		"traits": "Verbündeter. Krimineller."
 	},
 	{
@@ -48,7 +48,7 @@
 		"code": "05157",
 		"name": "Welken",
 		"slot": "Arkan",
-		"text": "[action]: <b>Kampf.</b> Dieser Angriff verwendet [willpower] statt [combat]. Falls ein [skull]-, [cultist]-, [tablet]- oder [elder_thing]-Symbol enthüllt wird, bekommt der angegriffene Gegner für den Rest des Zuges -1 Kampf und -1 Entkommen(bis zu einem Minimum von 1).",
+		"text": "[action]: <b>Kampf.</b> Dieser Angriff verwendet [willpower] statt [combat]. Falls ein [skull]-, [cultist]-, [tablet]- oder [elder_thing]-Symbol während dieses Angriffs enthüllt wird, bekommt der angegriffene Gegner für den Rest des Zuges -1 Kampf und -1 Entkommen (bis zu einem Minimum von 1).",
 		"traits": "Zauber."
 	},
 	{


### PR DESCRIPTION
Ich hab mal die restlichen Karten aus dem Der gebrochene Kreis-Zyklus übersetzt und ein paar kleine Fehler korrigiert. Wenn alles in Ordnung ist, kannst du die Daten an das Haupt-Repository weiterleiten.